### PR TITLE
Themes: Expose hardcoded contact tile text colors

### DIFF
--- a/res/layout/contact_tile_frequent.xml
+++ b/res/layout/contact_tile_frequent.xml
@@ -38,7 +38,7 @@
             android:id="@+id/contact_tile_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/black"
+            android:textColor="@color/frequent_contact_text_color"
             android:textSize="@dimen/contact_browser_list_item_text_size"
             android:singleLine="true"
             android:fadingEdge="horizontal"

--- a/res/layout/contact_tile_starred.xml
+++ b/res/layout/contact_tile_starred.xml
@@ -43,7 +43,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="7dp"
-            android:textColor="#202020"
+            android:textColor="@color/contact_tile_text_color"
             android:textSize="@dimen/contact_browser_list_item_text_size"
             android:singleLine="true"
             android:fadingEdge="horizontal"

--- a/res/layout/contact_tile_starred_quick_contact.xml
+++ b/res/layout/contact_tile_starred_quick_contact.xml
@@ -47,7 +47,7 @@
                 android:id="@+id/contact_tile_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"
+                android:textColor="@color/starred_quick_contact_name_text_color"
                 android:textSize="16sp"
                 android:singleLine="true"
                 android:fadingEdge="horizontal"

--- a/res/values/projekt_colors.xml
+++ b/res/values/projekt_colors.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 Project Substratum
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<resources>
+    <color name="frequent_contact_text_color">@android:color/black</color>
+    <color name="contact_tile_text_color">#ff202020</color>
+    <color name="starred_quick_contact_name_text_color">@android:color/white</color>
+</resources>


### PR DESCRIPTION
Naming conventions in line with @daveyannihilation's commit
https://github.com/daveyannihilation/Theme-Ready-Google-Contacts/commit/dedf7925f52bec3896b138fa3d9f3754218abb2d

Change-Id: I85aa4349ece8a9821d9443523b13f2234edd4af7